### PR TITLE
Switch Maven Central repo URL to HTTPS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
-	maven { url "http://repo.maven.apache.org/maven2" }
+	maven { url "https://repo.maven.apache.org/maven2" }
 }
 
 dependencies {


### PR DESCRIPTION
> Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.

See https://support.sonatype.com/hc/en-us/articles/360041287334 for details.

Closes #8.