### PR TITLE
Fix for bugs found in v5.4 confluent deploy

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/record/RecordSerde.java
+++ b/src/main/java/de/azapps/kafkabackup/common/record/RecordSerde.java
@@ -103,8 +103,14 @@ public class RecordSerde {
         } else {
             dataStream.writeInt(0);
         }
-        dataStream.writeInt(record.value().length);
-        dataStream.write(record.value());
+
+        if (record.value() != null) {
+            dataStream.writeInt(record.value().length);
+            dataStream.write(record.value());
+        }
+        else {
+            dataStream.writeInt(0);
+        }
         dataStream.writeInt(record.headers().size());
         for (Header header : record.headers()) {
             byte[] headerKeyBytes = header.key().getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/de/azapps/kafkabackup/common/segment/SegmentReader.java
+++ b/src/main/java/de/azapps/kafkabackup/common/segment/SegmentReader.java
@@ -46,8 +46,8 @@ public class SegmentReader {
 
     public void seek(long offset) throws IndexOutOfBoundsException, IOException {
         Optional<Long> optionalPosition = segmentIndex.findByOffset(offset);
-        if (optionalPosition.isEmpty()) {
-            throw new IndexOutOfBoundsException("Could not find offset " + offset + " in topic " + topic + ", segment " + filePrefix);
+        if (!optionalPosition.isPresent()) {
+            throw new IndexOutOfBoundsException("Could not find offset " + offset + " in topic " + topic + ", segment " + filePrefix + " ok " + optionalPosition);
         }
         recordInputStream.getChannel().position(optionalPosition.get());
     }


### PR DESCRIPTION
Fixes #13, #14 - restores java8 compatibility and handles writing tombstone Kafka records without crashing.

Thanks for your work writing this!  We're evaluating now, and agree there aren't great open solutions for Kafka backup thus far.