### PR TITLE
Fix #84: logging inconsistencies

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSource.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSource.java
@@ -55,7 +55,8 @@ public class OffsetSource {
                 Map<TopicPartition, OffsetAndMetadata> offsets = Collections.singletonMap(topicPartition, offsetAndMetadata);
                 consumer.commitSync(offsets);
                 consumer.close();
-                log.debug("Committed target offset " + (targetOffset + 1) + " for group " + group + " for topic " + topicPartition.topic() + " partition " + topicPartition.partition());
+                log.debug("Committed target offset {} for group {} for topic {} partition {}",
+                        (targetOffset + 1), group, topicPartition.topic(), topicPartition.partition());
             }
         }
     }

--- a/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
+++ b/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
@@ -67,7 +67,7 @@ public class BackupSinkTask extends SinkTask {
                 PartitionWriter partition = partitionWriters.get(topicPartition);
                 partition.append(Record.fromSinkRecord(sinkRecord));
                 if (sinkRecord.kafkaOffset() % 100 == 0) {
-                    log.debug("Backed up Topic %s, Partition %d, up to offset %d", sinkRecord.topic(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
+                    log.debug("Backed up Topic {}, Partition {}, up to offset {}", sinkRecord.topic(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
                 }
             }
             // Todo: refactor to own worker. E.g. using the scheduler of MM2

--- a/src/main/java/de/azapps/kafkabackup/source/BackupSourceTask.java
+++ b/src/main/java/de/azapps/kafkabackup/source/BackupSourceTask.java
@@ -90,7 +90,7 @@ public class BackupSourceTask extends SourceTask {
                         throw new RuntimeException(e);
                     }
                     partitionReaders.put(topicPartition, partitionReader);
-                    log.info("Registered topic " + topic + " partition " + partition);
+                    log.info("Registered topic {} partition {}", topic, partition);
                 }
             });
         }
@@ -113,10 +113,8 @@ public class BackupSourceTask extends SourceTask {
                 PartitionReader partitionReader = partitionReaders.get(topicPartition);
                 List<Record> records = partitionReader.readBytesBatch(batchSize);
                 if (records.size() > 0) {
-                    log.info("Read " + records.size() + " record " +
-                            "from topic " + records.get(0).topic() +
-                            " partition " + records.get(0).kafkaPartition() +
-                            ". Current offset: " + records.get(records.size() - 1).kafkaOffset());
+                    log.info("Read {} record(s) from topic {} partition {}. Current offset: {}",
+                            records.size(), records.get(0).topic(), records.get(0).kafkaPartition(), records.get(records.size() - 1).kafkaOffset());
                 }
                 for (Record record : records) {
                     sourceRecords.add(toSourceRecord(record));


### PR DESCRIPTION
- Consistently use log formatting via templates
- Fix wrong log output by using templates instead of %s